### PR TITLE
fix(config-example):  fix invalid parameter example

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -7,7 +7,7 @@ token: a12345a12345a12345a12345a12345a12345a123
 
 # Default Project ID
 # If set, used for all endpoints requiring project-id flag.
-#project-id: 373182575d64e892ba8ab2.58226357
+#project-id: '373182575d64e892ba8ab2.58226357'
 
 # Number of retries for API requests.
 # Default is 3.


### PR DESCRIPTION
resolves `API request error 400 Invalid `project_id` parameter` errors