### PR TITLE
Update go lokalise api

### DIFF
--- a/cmd/task.go
+++ b/cmd/task.go
@@ -35,7 +35,7 @@ var taskListCmd = &cobra.Command{
 	RunE: func(*cobra.Command, []string) error {
 		t := Api.Tasks()
 		pageOpts := lokalise.TaskListOptions{
-			Title: filterTitle,
+			FilterTitle: filterTitle,
 			Limit: t.ListOpts().Limit,
 		}
 
@@ -137,7 +137,6 @@ func init() {
 	_ = taskCreateCmd.MarkFlagRequired("languages")
 	fs.BoolVar(&autoCloseLang, "auto-close-languages", true, "Whether languages should be closed automatically upon completion of the last item (default true). Use --auto-close-languages=false to disable.")
 	fs.BoolVar(&autoCloseTask, "auto-close-task", true, "Whether the task should be automatically closed upon all language completion (default true). Use --auto-close-task=false to disable.")
-	fs.BoolVar(&newTask.InitialTMLeverage, "initial-tm-leverage", false, "Enable to calculate and save initial TM leverage with this task.")
 	fs.StringVar(&taskType, "task-type", "", "Specify if task type is `translation` (default) or `review`.")
 	fs.Int64Var(&newTask.ParentTaskID, "parent-task-id", 0, "If task_type is review, it can have a parent task. Current task will be opened when parent task is closed.")
 	fs.StringSliceVar(&newTask.ClosingTags, "closing-tags", []string{}, "Tags that will be added to affected keys when task is closed.")

--- a/cmd/translation.go
+++ b/cmd/translation.go
@@ -59,7 +59,7 @@ var translationUpdateCmd = &cobra.Command{
 	Long:  "Updates a translation.",
 	RunE: func(*cobra.Command, []string) error {
 		// processing opts
-		translationUpdate.IsFuzzy = &translationUpdateIsFuzzy
+		translationUpdate.IsUnverified = &translationUpdateIsFuzzy
 
 		resp, err := Api.Translations().Update(projectId, translationId, translationUpdate)
 		if err != nil {
@@ -79,9 +79,9 @@ func init() {
 	// List
 	fs := translationListCmd.Flags()
 	fs.Uint8Var(&translationListOpts.DisableReferences, "disable-references", 0, "Whether to disable key references.")
-	fs.StringVar(&translationListOpts.FilterLangID, "filter-lang-id", "", "Return translations only for presented language ID.")
+	fs.Int64Var(&translationListOpts.FilterLangID, "filter-lang-id", 0, "Return translations only for presented language ID.")
 	fs.Uint8Var(&translationListOpts.FilterIsReviewed, "filter-is-reviewed", 0, "Filter translations which are reviewed.")
-	fs.Uint8Var(&translationListOpts.FilterFuzzy, "filter-fuzzy", 0, "Filter translations which are unverified (fuzzy).")
+	fs.Uint8Var(&translationListOpts.FilterUnverified, "filter-fuzzy", 0, "Filter translations which are unverified (fuzzy).")
 	fs.StringVar(&translationListOpts.FilterQAIssues, "filter-qa-issues", "", "One or more QA issues to filter by. Possible values are spelling_and_grammar, placeholders, html, url_count, url, email_count, email, brackets, numbers, leading_whitespace, trailing_whitespace, double_space and special_placeholder.")
 
 	// Retrieve

--- a/docs/lokalise2_task_create.md
+++ b/docs/lokalise2_task_create.md
@@ -21,7 +21,6 @@ lokalise2 task create [flags]
       --do-lock-translations                 If set to 1, will lock translations for non-assigned project members.
       --due-date Y-m-d H:i:s                 Due date in Y-m-d H:i:s format. Example: `2018-12-24 23:59:59`.
   -h, --help                                 help for create
-      --initial-tm-leverage                  Enable to calculate and save initial TM leverage with this task.
       --keys ints                            List of keys identifiers, included in task. Required if parent_task_id is not specified.
       --languages users                      List of languages in the task. One of users or `groups` must be provided (JSON, required, see https://lokalise.com/api2docs/curl/#transition-create-a-task-post).
       --parent-task-id int                   If task_type is review, it can have a parent task. Current task will be opened when parent task is closed.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lokalise/lokalise-cli-2-go
 go 1.21
 
 require (
-	github.com/lokalise/go-lokalise-api/v3 v3.4.0
+	github.com/lokalise/go-lokalise-api/v4 v4.0.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0


### PR DESCRIPTION
This seems to be the minimal required change to update to API v4. You might want to consider doing more, but this is needed to adapt the compact key as added here: https://github.com/lokalise/go-lokalise-api/pull/51 to eventually close https://github.com/lokalise/lokalise-cli-2-go/issues/100