### PR TITLE
Add compact for file download

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -294,6 +294,7 @@ func init() {
 	fs.StringVar(&downloadOpts.JavaPropertiesEncoding, "java-properties-encoding", "", "(Java Properties export only). Encoding for .properties files. Allowed values are utf-8 and latin-1.")
 	fs.StringVar(&downloadOpts.JavaPropertiesSeparator, "java-properties-separator", "", "(Java Properties export only). Separator for keys/values in .properties files. Allowed values are = and :.")
 	fs.StringVar(&downloadOpts.BundleDescription, "bundle-description", "", "Description of the created bundle. Applies to ios_sdk or android_sdk OTA SDK bundles.")
+	fs.BoolVar(&downloadOpts.Compact, "compact", false, "Export the minimum required structure for use in production. Don't include metadata such as context, comments and screenshots.")
 
 	// Upload
 	fs = fileUploadCmd.Flags()

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -35,7 +35,7 @@ var taskListCmd = &cobra.Command{
 	RunE: func(*cobra.Command, []string) error {
 		t := Api.Tasks()
 		pageOpts := lokalise.TaskListOptions{
-			Title: filterTitle,
+			FilterTitle: filterTitle,
 			Limit: t.ListOpts().Limit,
 		}
 
@@ -137,7 +137,6 @@ func init() {
 	_ = taskCreateCmd.MarkFlagRequired("languages")
 	fs.BoolVar(&autoCloseLang, "auto-close-languages", true, "Whether languages should be closed automatically upon completion of the last item (default true). Use --auto-close-languages=false to disable.")
 	fs.BoolVar(&autoCloseTask, "auto-close-task", true, "Whether the task should be automatically closed upon all language completion (default true). Use --auto-close-task=false to disable.")
-	fs.BoolVar(&newTask.InitialTMLeverage, "initial-tm-leverage", false, "Enable to calculate and save initial TM leverage with this task.")
 	fs.StringVar(&taskType, "task-type", "", "Specify if task type is `translation` (default) or `review`.")
 	fs.Int64Var(&newTask.ParentTaskID, "parent-task-id", 0, "If task_type is review, it can have a parent task. Current task will be opened when parent task is closed.")
 	fs.StringSliceVar(&newTask.ClosingTags, "closing-tags", []string{}, "Tags that will be added to affected keys when task is closed.")

--- a/cmd/translation.go
+++ b/cmd/translation.go
@@ -59,7 +59,7 @@ var translationUpdateCmd = &cobra.Command{
 	Long:  "Updates a translation.",
 	RunE: func(*cobra.Command, []string) error {
 		// processing opts
-		translationUpdate.IsFuzzy = &translationUpdateIsFuzzy
+		translationUpdate.IsUnverified = &translationUpdateIsFuzzy
 
 		resp, err := Api.Translations().Update(projectId, translationId, translationUpdate)
 		if err != nil {
@@ -79,9 +79,9 @@ func init() {
 	// List
 	fs := translationListCmd.Flags()
 	fs.Uint8Var(&translationListOpts.DisableReferences, "disable-references", 0, "Whether to disable key references.")
-	fs.StringVar(&translationListOpts.FilterLangID, "filter-lang-id", "", "Return translations only for presented language ID.")
+	fs.Int64Var(&translationListOpts.FilterLangID, "filter-lang-id", 0, "Return translations only for presented language ID.")
 	fs.Uint8Var(&translationListOpts.FilterIsReviewed, "filter-is-reviewed", 0, "Filter translations which are reviewed.")
-	fs.Uint8Var(&translationListOpts.FilterFuzzy, "filter-fuzzy", 0, "Filter translations which are unverified (fuzzy).")
+	fs.Uint8Var(&translationListOpts.FilterUnverified, "filter-fuzzy", 0, "Filter translations which are unverified (fuzzy).")
 	fs.StringVar(&translationListOpts.FilterQAIssues, "filter-qa-issues", "", "One or more QA issues to filter by. Possible values are spelling_and_grammar, placeholders, html, url_count, url, email_count, email, brackets, numbers, leading_whitespace, trailing_whitespace, double_space and special_placeholder.")
 
 	// Retrieve

--- a/docs/lokalise2_file_download.md
+++ b/docs/lokalise2_file_download.md
@@ -17,6 +17,7 @@ lokalise2 file download [flags]
       --all-platforms                           Enable to include all platform keys. If disabled, only the keys, associated with the platform of the format will be exported.
       --bundle-description string               Description of the created bundle. Applies to ios_sdk or android_sdk OTA SDK bundles.
       --bundle-structure string                 Bundle structure, used when original-filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%).
+      --compact                                 Export the minimum required structure for use in production. Don't include metadata such as context, comments and screenshots.
       --custom-translation-status-ids strings   Only translations attributed to selected custom statuses will be included. Leave empty for all.
       --dest string                             Destination folder for ZIP file. (default "./")
       --directory-prefix string                 Directory prefix in the bundle (used when original-filenames set to true). Allowed placeholder is %LANG_ISO%.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lokalise/lokalise-cli-2-go
 go 1.21
 
 require (
-	github.com/lokalise/go-lokalise-api/v3 v3.4.0
+	github.com/lokalise/go-lokalise-api/v4 v4.0.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0


### PR DESCRIPTION
This PR will add a flag for applying the compact attribute for file download. It's still blocked by other PRs and need more updates, but at least it gives insight of what needs to change to apply this.

NOTE: This PR also contains changes from https://github.com/lokalise/lokalise-cli-2-go/pull/126.

Blocked by:
 - https://github.com/lokalise/lokalise-cli-2-go/pull/126
 - https://github.com/lokalise/go-lokalise-api/pull/51
Closes: https://github.com/lokalise/lokalise-cli-2-go/issues/100