### PR TITLE
Add bulk key operations: bulk-create, bulk-update, bulk-delete

### DIFF
--- a/cmd/key.go
+++ b/cmd/key.go
@@ -20,6 +20,10 @@ var (
 	newKeyTranslations string
 
 	useAutomations bool
+
+	bulkDeleteKeyIds []int
+	bulkUpdateKeys   string
+	bulkCreateKeys   string
 )
 
 // keyCmd represents the key command
@@ -128,8 +132,71 @@ var keyDeleteCmd = &cobra.Command{
 	},
 }
 
+var keyBulkDeleteCmd = &cobra.Command{
+	Use:   "bulk-delete",
+	Short: "Delete multiple keys",
+	Long:  "Deletes multiple keys from the project. Requires Manage keys admin right.",
+	RunE: func(*cobra.Command, []string) error {
+		var keyIDs []int64
+		for _, id := range bulkDeleteKeyIds {
+			keyIDs = append(keyIDs, int64(id))
+		}
+
+		resp, err := Api.Keys().BulkDelete(projectId, keyIDs)
+		if err != nil {
+			return err
+		}
+		return printJson(resp)
+	},
+}
+
+var keyBulkUpdateCmd = &cobra.Command{
+	Use:   "bulk-update",
+	Short: "Update multiple keys",
+	Long:  "Updates multiple keys in the project. Requires Manage keys admin right.",
+	RunE: func(*cobra.Command, []string) error {
+		var keys []lokalise.BulkUpdateKey
+		if err := json.Unmarshal([]byte(bulkUpdateKeys), &keys); err != nil {
+			return err
+		}
+
+		resp, err := Api.Keys().BulkUpdate(
+			projectId,
+			keys,
+			lokalise.WithAutomations(useAutomations),
+		)
+		if err != nil {
+			return err
+		}
+		return printJson(resp)
+	},
+}
+
+var keyBulkCreateCmd = &cobra.Command{
+	Use:   "bulk-create",
+	Short: "Create multiple keys",
+	Long:  "Creates multiple keys in the project from a JSON array.",
+	RunE: func(*cobra.Command, []string) error {
+		var keys []lokalise.NewKey
+		if err := json.Unmarshal([]byte(bulkCreateKeys), &keys); err != nil {
+			return err
+		}
+
+		resp, err := Api.Keys().Create(
+			projectId,
+			keys,
+			lokalise.WithAutomations(useAutomations),
+		)
+		if err != nil {
+			return err
+		}
+		return printJson(resp)
+	},
+}
+
 func init() {
-	keyCmd.AddCommand(keyListCmd, keyCreateCmd, keyRetrieveCmd, keyUpdateCmd, keyDeleteCmd)
+	keyCmd.AddCommand(keyListCmd, keyCreateCmd, keyRetrieveCmd, keyUpdateCmd, keyDeleteCmd,
+		keyBulkDeleteCmd, keyBulkUpdateCmd, keyBulkCreateCmd)
 	rootCmd.AddCommand(keyCmd)
 
 	// common for all Comment cmd`s
@@ -194,6 +261,27 @@ func init() {
 	keyRetrieveCmd.Flags().Uint8Var(&keyListOpts.DisableReferences, "disable-references", 0, "Whether to disable key references.")
 
 	flagKeyId(keyDeleteCmd)
+
+	// Bulk delete
+	keyBulkDeleteCmd.Flags().IntSliceVar(&bulkDeleteKeyIds, "key-ids", []int{},
+		"Comma-separated list of key IDs to delete (required).")
+	_ = keyBulkDeleteCmd.MarkFlagRequired("key-ids")
+
+	// Bulk update
+	fs = keyBulkUpdateCmd.Flags()
+	fs.StringVar(&bulkUpdateKeys, "keys", "",
+		"JSON array of key objects to update. Each object must contain key_id and fields to update (required).")
+	_ = keyBulkUpdateCmd.MarkFlagRequired("keys")
+	fs.BoolVar(&useAutomations, "use-automations", true,
+		"Whether to run automations on the updated key translations.")
+
+	// Bulk create
+	fs = keyBulkCreateCmd.Flags()
+	fs.StringVar(&bulkCreateKeys, "keys", "",
+		"JSON array of key objects to create. Each object should contain key_name, platforms, and other fields (required).")
+	_ = keyBulkCreateCmd.MarkFlagRequired("keys")
+	fs.BoolVar(&useAutomations, "use-automations", true,
+		"Whether to run automations on the new key translations.")
 }
 
 func flagKeyId(cmd *cobra.Command) {

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -145,6 +145,9 @@ var keyBulkDeleteCmd = &cobra.Command{
 	Short: "Delete multiple keys",
 	Long:  "Deletes multiple keys from the project. Requires Manage keys admin right.",
 	RunE: func(*cobra.Command, []string) error {
+		if len(bulkDeleteKeyIds) == 0 {
+			return errors.New("--key-ids must contain at least one key ID")
+		}
 		resp, err := Api.Keys().BulkDelete(projectId, bulkDeleteKeyIds)
 		if err != nil {
 			return err

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/lokalise/go-lokalise-api/v4"
 	"github.com/spf13/cobra"
@@ -161,6 +162,9 @@ var keyBulkUpdateCmd = &cobra.Command{
 		if err := json.Unmarshal([]byte(bulkUpdateKeys), &keys); err != nil {
 			return err
 		}
+		if len(keys) == 0 {
+			return errors.New("--keys must contain at least one key object")
+		}
 
 		resp, err := Api.Keys().BulkUpdate(
 			projectId,
@@ -182,6 +186,9 @@ var keyBulkCreateCmd = &cobra.Command{
 		var keys []lokalise.NewKey
 		if err := json.Unmarshal([]byte(bulkCreateKeys), &keys); err != nil {
 			return err
+		}
+		if len(keys) == 0 {
+			return errors.New("--keys must contain at least one key object")
 		}
 
 		resp, err := Api.Keys().Create(

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -21,9 +21,16 @@ var (
 
 	useAutomations bool
 
-	bulkDeleteKeyIds []int
-	bulkUpdateKeys   string
-	bulkCreateKeys   string
+	// bulk-delete
+	bulkDeleteKeyIds []int64
+
+	// bulk-update
+	bulkUpdateKeys           string
+	bulkUpdateUseAutomations bool
+
+	// bulk-create
+	bulkCreateKeys           string
+	bulkCreateUseAutomations bool
 )
 
 // keyCmd represents the key command
@@ -137,12 +144,7 @@ var keyBulkDeleteCmd = &cobra.Command{
 	Short: "Delete multiple keys",
 	Long:  "Deletes multiple keys from the project. Requires Manage keys admin right.",
 	RunE: func(*cobra.Command, []string) error {
-		var keyIDs []int64
-		for _, id := range bulkDeleteKeyIds {
-			keyIDs = append(keyIDs, int64(id))
-		}
-
-		resp, err := Api.Keys().BulkDelete(projectId, keyIDs)
+		resp, err := Api.Keys().BulkDelete(projectId, bulkDeleteKeyIds)
 		if err != nil {
 			return err
 		}
@@ -163,7 +165,7 @@ var keyBulkUpdateCmd = &cobra.Command{
 		resp, err := Api.Keys().BulkUpdate(
 			projectId,
 			keys,
-			lokalise.WithAutomations(useAutomations),
+			lokalise.WithAutomations(bulkUpdateUseAutomations),
 		)
 		if err != nil {
 			return err
@@ -185,7 +187,7 @@ var keyBulkCreateCmd = &cobra.Command{
 		resp, err := Api.Keys().Create(
 			projectId,
 			keys,
-			lokalise.WithAutomations(useAutomations),
+			lokalise.WithAutomations(bulkCreateUseAutomations),
 		)
 		if err != nil {
 			return err
@@ -263,7 +265,7 @@ func init() {
 	flagKeyId(keyDeleteCmd)
 
 	// Bulk delete
-	keyBulkDeleteCmd.Flags().IntSliceVar(&bulkDeleteKeyIds, "key-ids", []int{},
+	keyBulkDeleteCmd.Flags().Int64SliceVar(&bulkDeleteKeyIds, "key-ids", []int64{},
 		"Comma-separated list of key IDs to delete (required).")
 	_ = keyBulkDeleteCmd.MarkFlagRequired("key-ids")
 
@@ -272,7 +274,7 @@ func init() {
 	fs.StringVar(&bulkUpdateKeys, "keys", "",
 		"JSON array of key objects to update. Each object must contain key_id and fields to update (required).")
 	_ = keyBulkUpdateCmd.MarkFlagRequired("keys")
-	fs.BoolVar(&useAutomations, "use-automations", true,
+	fs.BoolVar(&bulkUpdateUseAutomations, "use-automations", true,
 		"Whether to run automations on the updated key translations.")
 
 	// Bulk create
@@ -280,7 +282,7 @@ func init() {
 	fs.StringVar(&bulkCreateKeys, "keys", "",
 		"JSON array of key objects to create. Each object should contain key_name, platforms, and other fields (required).")
 	_ = keyBulkCreateCmd.MarkFlagRequired("keys")
-	fs.BoolVar(&useAutomations, "use-automations", true,
+	fs.BoolVar(&bulkCreateUseAutomations, "use-automations", true,
 		"Whether to run automations on the new key translations.")
 }
 

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -162,6 +162,74 @@ func TestKeyBulkCreate(t *testing.T) {
 	}
 }
 
+func TestKeyBulkUpdate_UseAutomationsFalse(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(
+		fmt.Sprintf("/api2/projects/%s/keys", testProjectID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			testMethod(t, r, "PUT")
+			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			data := `{"keys":[{"key_id":123,"description":"Updated"}],"use_automations":false}`
+			req := new(bytes.Buffer)
+			_ = json.Compact(req, []byte(data))
+			testBody(t, r, req.String())
+
+			_, _ = fmt.Fprint(w, `{
+				"project_id": "`+testProjectID+`",
+				"keys": [{"key_id": 123}]
+			}`)
+		})
+
+	keysJSON := `[{"key_id":123,"description":"Updated"}]`
+	args := []string{"key", "bulk-update", "--keys=" + keysJSON, "--project-id=" + testProjectID, "--use-automations=false"}
+	rootCmd.SetArgs(args)
+	keyBulkUpdateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestKeyBulkCreate_UseAutomationsFalse(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(
+		fmt.Sprintf("/api2/projects/%s/keys", testProjectID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			testMethod(t, r, "POST")
+			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			data := `{"keys":[{"key_name":"welcome","platforms":["web"],"tags":[]}],"use_automations":false}`
+			req := new(bytes.Buffer)
+			_ = json.Compact(req, []byte(data))
+			testBody(t, r, req.String())
+
+			_, _ = fmt.Fprint(w, `{
+				"project_id": "`+testProjectID+`",
+				"keys": [{"key_id": 789}]
+			}`)
+		})
+
+	keysJSON := `[{"key_name":"welcome","platforms":["web"],"tags":[]}]`
+	args := []string{"key", "bulk-create", "--keys=" + keysJSON, "--project-id=" + testProjectID, "--use-automations=false"}
+	rootCmd.SetArgs(args)
+	keyBulkCreateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
 func TestKeyBulkUpdate_InvalidJSON(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
@@ -191,5 +259,37 @@ func TestKeyBulkCreate_InvalidJSON(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestKeyBulkUpdate_EmptyKeys(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	args := []string{"key", "bulk-update", "--keys=[]", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkUpdateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("Expected error for empty keys, got nil")
+	}
+}
+
+func TestKeyBulkCreate_EmptyKeys(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	args := []string{"key", "bulk-create", "--keys=[]", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkCreateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("Expected error for empty keys, got nil")
 	}
 }

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -55,6 +55,11 @@ func TestKeyBulkUpdate(t *testing.T) {
 			testMethod(t, r, "PUT")
 			testHeader(t, r, "X-Api-Token", testApiToken)
 
+			data := `{"keys":[{"key_id":123,"description":"Updated description","tags":["updated"]}],"use_automations":true}`
+			req := new(bytes.Buffer)
+			_ = json.Compact(req, []byte(data))
+			testBody(t, r, req.String())
+
 			_, _ = fmt.Fprint(w, `{
 				"project_id": "`+testProjectID+`",
 				"keys": [
@@ -100,6 +105,11 @@ func TestKeyBulkCreate(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			testMethod(t, r, "POST")
 			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			data := `{"keys":[{"key_name":"welcome","platforms":["web"],"tags":[]},{"key_name":"goodbye","platforms":["ios","android"],"tags":["v2"]}],"use_automations":true}`
+			req := new(bytes.Buffer)
+			_ = json.Compact(req, []byte(data))
+			testBody(t, r, req.String())
 
 			_, _ = fmt.Fprint(w, `{
 				"project_id": "`+testProjectID+`",

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestKeyBulkDelete(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(
+		fmt.Sprintf("/api2/projects/%s/keys", testProjectID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			testMethod(t, r, "DELETE")
+			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			data := `{"keys":[123,456]}`
+			req := new(bytes.Buffer)
+			_ = json.Compact(req, []byte(data))
+			testBody(t, r, req.String())
+
+			_, _ = fmt.Fprint(w, `{
+				"project_id": "`+testProjectID+`",
+				"keys_removed": true,
+				"keys_locked": 0
+			}`)
+		})
+
+	args := []string{"key", "bulk-delete", "--key-ids=123,456", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkDeleteCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestKeyBulkUpdate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(
+		fmt.Sprintf("/api2/projects/%s/keys", testProjectID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			testMethod(t, r, "PUT")
+			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			_, _ = fmt.Fprint(w, `{
+				"project_id": "`+testProjectID+`",
+				"keys": [
+					{
+						"key_id": 123,
+						"key_name": {
+							"ios": "updated_key",
+							"android": "updated_key",
+							"web": "updated_key",
+							"other": "updated_key"
+						},
+						"platforms": ["web"],
+						"filenames": {},
+						"description": "Updated description",
+						"tags": ["updated"],
+						"comments": [],
+						"screenshots": [],
+						"translations": []
+					}
+				]
+			}`)
+		})
+
+	keysJSON := `[{"key_id":123,"description":"Updated description","tags":["updated"]}]`
+	args := []string{"key", "bulk-update", "--keys=" + keysJSON, "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkUpdateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestKeyBulkCreate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(
+		fmt.Sprintf("/api2/projects/%s/keys", testProjectID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			testMethod(t, r, "POST")
+			testHeader(t, r, "X-Api-Token", testApiToken)
+
+			_, _ = fmt.Fprint(w, `{
+				"project_id": "`+testProjectID+`",
+				"keys": [
+					{
+						"key_id": 789,
+						"key_name": {
+							"ios": "welcome",
+							"android": "welcome",
+							"web": "welcome",
+							"other": "welcome"
+						},
+						"platforms": ["web"],
+						"filenames": {},
+						"description": "",
+						"tags": [],
+						"comments": [],
+						"screenshots": [],
+						"translations": []
+					},
+					{
+						"key_id": 790,
+						"key_name": {
+							"ios": "goodbye",
+							"android": "goodbye",
+							"web": "goodbye",
+							"other": "goodbye"
+						},
+						"platforms": ["ios", "android"],
+						"filenames": {},
+						"description": "",
+						"tags": ["v2"],
+						"comments": [],
+						"screenshots": [],
+						"translations": []
+					}
+				]
+			}`)
+		})
+
+	keysJSON := `[{"key_name":"welcome","platforms":["web"],"tags":[]},{"key_name":"goodbye","platforms":["ios","android"],"tags":["v2"]}]`
+	args := []string{"key", "bulk-create", "--keys=" + keysJSON, "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkCreateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestKeyBulkUpdate_InvalidJSON(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	args := []string{"key", "bulk-update", "--keys=not-json", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkUpdateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestKeyBulkCreate_InvalidJSON(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	args := []string{"key", "bulk-create", "--keys=not-json", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkCreateCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -243,6 +244,8 @@ func TestKeyBulkUpdate_InvalidJSON(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
+	} else if !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("Expected JSON parse error, got: %v", err)
 	}
 }
 
@@ -259,6 +262,27 @@ func TestKeyBulkCreate_InvalidJSON(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
+	} else if !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("Expected JSON parse error, got: %v", err)
+	}
+}
+
+func TestKeyBulkDelete_EmptyKeyIds(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	// Reset package-level var that may retain state from prior tests
+	bulkDeleteKeyIds = []int64{}
+
+	args := []string{"key", "bulk-delete", "--key-ids=", "--project-id=" + testProjectID}
+	rootCmd.SetArgs(args)
+	keyBulkDeleteCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		Api = client
+	}
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("Expected error for empty key-ids, got nil")
 	}
 }
 
@@ -275,6 +299,8 @@ func TestKeyBulkUpdate_EmptyKeys(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error for empty keys, got nil")
+	} else if err.Error() != "--keys must contain at least one key object" {
+		t.Errorf("Expected empty keys error, got: %v", err)
 	}
 }
 
@@ -291,5 +317,8 @@ func TestKeyBulkCreate_EmptyKeys(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error for empty keys, got nil")
+	} else if err.Error() != "--keys must contain at least one key object" {
+		t.Errorf("Expected empty keys error, got: %v", err)
 	}
 }
+


### PR DESCRIPTION
## Problem

The [Lokalise API](https://developers.lokalise.com/reference/list-all-keys) supports bulk operations on keys — creating multiple keys in a single request, updating multiple keys at once, and deleting multiple keys by ID. The underlying Go SDK (`go-lokalise-api/v4`) already exposes these capabilities:

- `Keys().Create(projectID, []NewKey{...})` — accepts a slice of keys
- `Keys().BulkUpdate(projectID, []BulkUpdateKey{...})` — dedicated bulk update method
- `Keys().BulkDelete(projectID, []int64{...})` — dedicated bulk delete method

However, the CLI only wraps these as single-item operations:

- `key create` wraps one `NewKey` in a slice
- `key update` calls `Keys().Update()` (single key only)
- `key delete` calls `Keys().Delete()` (single key only)

This forces users who need to operate on many keys to loop over individual CLI calls, resulting in `N` API requests instead of `1`. For projects with hundreds or thousands of keys, this is a significant usability and performance gap — especially for common workflows like batch tagging, archiving unused keys, or bootstrapping a new project with a predefined key set.

## Solution

Three new subcommands under `key`:

### `key bulk-delete`
Accepts a comma-separated list of key IDs and calls `Keys().BulkDelete()`.

```bash
lokalise2 key bulk-delete --project-id <id> --key-ids 123,456,789
```

### `key bulk-update`
Accepts a JSON array of `BulkUpdateKey` objects (each containing `key_id` and fields to update) and calls `Keys().BulkUpdate()`.

```bash
lokalise2 key bulk-update --project-id <id> \
  --keys '[{"key_id":123,"description":"Updated","tags":["v2"]},{"key_id":456,"is_hidden":true}]'
```

### `key bulk-create`
Accepts a JSON array of `NewKey` objects and calls `Keys().Create()` with the full slice.

```bash
lokalise2 key bulk-create --project-id <id> \
  --keys '[{"key_name":"welcome","platforms":["web"],"tags":[]},{"key_name":"goodbye","platforms":["ios"],"tags":["v2"]}]'
```

Both `bulk-update` and `bulk-create` support the existing `--use-automations` flag (default `true`).

## Design decisions

- **New subcommands instead of modifying existing ones** — `bulk-delete` and `bulk-update` map to distinct SDK methods with different signatures. Keeping them separate avoids backward-compatibility concerns and keeps each command focused.
- **`--key-ids` as IntSlice for bulk-delete** — follows the existing pattern from `team-user-group add-members` (`IntSliceVar` + `int-to-int64` conversion).
- **`--keys` as JSON string for bulk-update/create** — follows the existing pattern of JSON string flags (`--translations`, `--filenames`). For large payloads, users can use `--keys "$(cat keys.json)"`.
- **Existing commands untouched** — `key create`, `key update`, and `key delete` are not modified. Zero breaking changes.

## Test plan

- [x] Unit tests added (`cmd/key_test.go`) covering all three commands + invalid JSON error handling
- [x] `go test ./...` passes
- [x] `go build ./...` passes
- [x] Verified end-to-end against a live Lokalise project:
  - `bulk-create` created 2 keys in one API call
  - `bulk-update` updated descriptions and tags on both keys in one call
  - `bulk-delete` deleted both keys in one call (`keys_removed: true`)