### PR TITLE
PERF-1959 Translation order fails with 400 Invalid `payment_method` on CLI v3.1.0+

### DIFF
--- a/cmd/order.go
+++ b/cmd/order.go
@@ -78,6 +78,7 @@ func init() {
 	_ = orderCreateCmd.MarkFlagRequired("project-id")
 	fs.Int64Var(&newOrder.CardID, "card-id", 0, "Card identifier that should be used for payment. (required).")
 	_ = orderCreateCmd.MarkFlagRequired("card-id")
+	fs.StringVar(&newOrder.PaymentMethod, "payment-method", "credit_card", "Payment method to use for the order. Available values are credit_card, team_credit.")
 	fs.StringVar(&newOrder.Briefing, "briefing", "", "Order briefing (required).")
 	_ = orderCreateCmd.MarkFlagRequired("briefing")
 	fs.StringVar(&newOrder.SourceLangISO, "source-language-iso", "", "Source language code of the order (required).")

--- a/docs/lokalise2_order_create.md
+++ b/docs/lokalise2_order_create.md
@@ -18,6 +18,7 @@ lokalise2 order create [flags]
       --dry-run                        Return the response without actually placing an order. Useful for price estimation. The card will not be charged.
   -h, --help                           help for create
       --keys ints                      List of keys identifiers, included in the order (required).
+      --payment-method string          Payment method to use for the order. Available values are credit_card, team_credit. (default "credit_card")
       --project-id string              Project identifier. (required).
       --provider-slug string           Translation provider slug (required).
       --source-language-iso string     Source language code of the order (required).


### PR DESCRIPTION
Order create requests were failing with 400 Invalid `payment_method` because the API's order create endpoint now requires an explicit `payment_method` value, and the CLI had no way to set it.

- Added a `--payment-method` flag to `lokalise2 order create`
- Defaulted the flag to `credit_card` rather than an empty string. The CreateOrder.PaymentMethod field has no omitempty JSON tag, so an unset flag was serializing to "payment_method":"" in the request body — the actual cause of the 400 — rather than being omitted. Defaulting the flag itself to a valid value fixes this without touching the vendored library.
- Updated `docs/lokalise2_order_create.md` to document the new flag and its default.
